### PR TITLE
Major update to original version

### DIFF
--- a/credentialType.ttl
+++ b/credentialType.ttl
@@ -13,67 +13,68 @@
 credType: a skos:ConceptScheme;
    dc:title "CTI Credential Type Vocabulary" ;
    dc:creator "Credential Transparency Initiative (CTI)"@en-US ;
-   dc:description "A concept scheme that defines the categories of credentials in the credential ecosystem."@en-US ;
+   dc:description "A concept scheme that defines the categories of credentials in the education-workforce development ecosystem."@en-US ;
    dct:created "2016-05-04"^^xsd:date ;
-   dct:license <http://creativecommons.org/licenses/by/4.0/> ;
+   dct:modified "2016-06-26"^^xsd:date ;
    skos:hasTopConcept credType:apprenticeship;
    skos:hasTopConcept credType:certificate;
    skos:hasTopConcept credType:certification;
    skos:hasTopConcept credType:degree;
-   skos:hasTopConcept credType:digitalBadge;
+   skos:hasTopConcept credType:digitalBadge;   
    skos:hasTopConcept credType:diploma;
    skos:hasTopConcept credType:license;
    skos:hasTopConcept credType:microCredential;
-   skos:hasTopConcept credType:militaryCredential;
-   skos:hasTopConcept credType:nanodegree;                          
+   skos:hasTopConcept credType:qualityAssuranceCredential;
+   dct:source "Sources consulted include, but are not limited to: Integrated Postsecondary Education Data System (IPEDS) and Common Education Data Standards (CEDS)."@en-US ;
+   dct:license <http://creativecommons.org/licenses/by/4.0/> ;                         
    adms:status bibo:draft .  
 
-# APPRENTICESHIP  
-credType:apprenticeship a skos:Concept;
-   skos:prefLabel "Apprenticeship"@en-US; 
-   skos:definition "Skill-based occupational proficiency determined by trade organizations."@en-US;
+# APPRENTICESHIP CERTIFICATE 
+credType:apprenticeshipCertificate a skos:Concept ;
+   skos:prefLabel "Apprenticeship Certificate"@en-US ; 
+   skos:definition "A credential earned through work-based learning and postsecondary earn-and-learn models that meet national standards and are applicable to industry trades and professions."@en-US;
+   skos:broader credType:certificate ;
    skos:inScheme credType: ;
    vs:term_status "unstable" .
 
 # CERTIFICATE    
 credType:certificate a skos:Concept;
   skos:prefLabel "Certificate"@en-US; 
-  skos:definition "Document (letter, card, or other medium) awarded to certificate holders that designates the successful completion of a certificate program’s requisites."@en-US;
-  skos:narrower credType:jobSkillsCertificate ;
-  skos:narrower credType:industryJobCertificate ;
+  skos:definition "A credential that designates requisite mastery of the knowledge and skills of an occupation, profession, or academic program."@en-US;
+  skos:narrower credType:apprenticeshipCertificate ;
   skos:inScheme credType: ;
   vs:term_status "unstable" .
 
-# JOB SKILLS CERTIFICATE  
-credType:jobSkillsCertificate a skos:Concept;
-  skos:prefLabel "Certificate (Job Skills)"@en-US; 
-  skos:definition "Document (letter, card, or other medium) awarded to certificate holders that designates the successful completion of a certificate program’s requisites for a specific job skill."@en-US;
-  skos:broader credType:certificate;
+# JOURNEYMAN CERTIFICATE  
+credType:journeymanCertificate a skos:Concept;
+  skos:prefLabel "Journeyman Certificate"@en-US; 
+  skos:definition "A credential awarded to skilled workers on successful completion of an apprenticeship in industry trades and professions."@en-US;
+  skos:broader credType:apprenticeshipCertificate;
   skos:inScheme credType: ;
   vs:term_status "unstable" .
   
-# INDUSTRY JOB  CERTIFICATE  
-credType:industryJobCertificate a skos:Concept;
-  skos:prefLabel "Certificate (Industry Job)"@en-US; 
-  skos:definition "Document (letter, card, or other medium) awarded to certificate holders that designates the successful completion of a certificate program’s requisites for a specific industry job."@en-US;
-  skos:broader credType:certificate;
+# MASTER  CERTIFICATE  
+credType:masterCertificate a skos:Concept;
+  skos:prefLabel "Master Certificate"@en-US; 
+  skos:definition "A credential awarded upon demonstration through apprenticeship of the the highest level of skills and performance in industry trades and professions."@en-US;
+  skos:broader credType:apprenticeshipCertificate;
   skos:inScheme credType: ;
   vs:term_status "unstable" .
   
 # CERTIFICATION    
 credType:certification a skos:Concept;
   skos:prefLabel "Certification"@en-US; 
-  skos:definition "Designation earned by a person to assure qualification to perform a job or task through assessment and issuance of a renewable certification."@en-US;
+  skos:definition "A time-limited, renewable non-degree credential awarded by an authoritative body to an individual or organization for demonstrating the designated knowledge, skills, and abilities to perform a specific job."@en-US;
   skos:inScheme credType: ;
   vs:term_status "unstable" . 
   
 # DEGREE    
 credType:degree a skos:Concept ;
   skos:prefLabel "Degree"@en-US ; 
-  skos:definition "State of recognized completion of studies that is earned or conferred at an accredited school or postsecondary institution."@en-US ;
+  skos:definition "An academic credential conferred upon completion of a program or course of study, typically over multiple years at postsecondary education institutions."@en-US ;
   skos:narrower credType:associateDegree ; 
   skos:narrower credType:bachelorDegree ;
-  skos:narrower credType:graduateDegree ; 
+  skos:narrower credType:masterDegree ; 
   skos:narrower credType:doctoralDegree ;    
   skos:inScheme credType: ;
   vs:term_status "unstable" .
@@ -81,23 +82,23 @@ credType:degree a skos:Concept ;
 # ASSOCIATE DEGREE
 credType:associateDegree a skos:Concept ;
   skos:prefLabel "Associate Degree"@en-US ; 
-  skos:definition "Undergraduate academic degree awarded in the U.S. by colleges and universities upon completion of a course of study lasting two years."@en-US ;
+  skos:definition "An award level that normally requires at least 2 but less than 4 years of full-time equivalent college-level work."@en-US ;
   skos:broader credType:degree ;
   skos:inScheme credType: ;
   vs:term_status "unstable" .
   
-# BACHELOR DEGREE
+# BACHELOR'S DEGREE
 credType:bachelorDegree a skos:Concept ;
-  skos:prefLabel "Bachelor Degree"@en-US ; 
-  skos:definition "A bachelor degree is usually earned for an undergraduate course of study that normally requires four years of study."@en-US ;
+  skos:prefLabel "Bachelor's Degree"@en-US ; 
+  skos:definition "An award level that normally requires at least 4 but not more than 5 years of full-time equivalent college-level work."@en-US ;
   skos:broader credType:degree ;
   skos:inScheme credType: ;
   vs:term_status "unstable" .
 
-# GRADUATE DEGREE
-credType:graduateDegree a skos:Concept ;
-  skos:prefLabel "Graduate Degree"@en-US ; 
-  skos:definition "A graduate degree is a post-baccalaureate, advanced degree at the masters or professional level."@en-US ;
+# MASTER'S DEGREE
+credType:masterDegree a skos:Concept ;
+  skos:prefLabel "Master's Degree"@en-US ; 
+  skos:definition "An award level that requires the successful completion of a program of study of at least the full-time equivalent of 1 but not more than 2 academic years of work beyond the bachelor's degree."@en-US ;
   skos:broader credType:degree ;
   skos:inScheme credType: ;
   vs:term_status "unstable" .
@@ -105,12 +106,31 @@ credType:graduateDegree a skos:Concept ;
 # DOCTORAL DEGREE
 credType:doctoralDegree a skos:Concept ;
   skos:prefLabel "Doctoral Degree"@en-US ; 
-  skos:definition "A doctorate degree is the highest level of academic degree."@en-US ;
+  skos:definition "The highest award level to be earned for postsecondary study."@en-US ;
   skos:broader credType:degree ;
+  skos:narrower credType:researchDoctorate ;
+  skos:narrower credType:professionalDoctorate ;     
   skos:inScheme credType: ;
   vs:term_status "unstable" .
   
-# DIGITAL BADGE    
+# RESEARCH DOCTORATE
+credType:researchDoctorate a skos:Concept ;
+  skos:prefLabel "Research Doctorate"@en-US ; 
+  skos:definition "A doctoral degree conferred for advanced work beyond the master level, including the preparation and defense of a thesis or dissertation based on original research, or the planning and execution of an original project demonstrating substantial artistic or scholarly achievement."@en-US ;
+  skos:broader credType:doctoralDegree ;
+  skos:inScheme credType: ;
+  vs:term_status "unstable" .
+  
+# PROFESSIONAL DOCTORATE
+credType:professionalDoctorate a skos:Concept ;
+  skos:prefLabel "Professional Doctorate"@en-US ; 
+  skos:definition "A doctoral degree conferred upon completion of a program providing the knowledge and skills for the recognition, credential, or license required for professional practice."@en-US ;
+  skos:broader credType:doctoralDegree ;
+  skos:inScheme credType: ;
+  vs:term_status "unstable" .  
+  
+# DIGITAL BADGE
+# 2016-06-26 NOTE: DISPOSITION OF "DIGITAL BADGE" UNDER DISCUSSION IN TAC  
 credType:digitalBadge a skos:Concept;
   skos:prefLabel "Digital Badge"@en-US; 
   skos:definition "Validated indicator of accomplishment, skill, quality, or interest that can be earned in many learning environments issued as a digital badge."@en-US;
@@ -121,34 +141,44 @@ credType:digitalBadge a skos:Concept;
 credType:diploma a skos:Concept;
   skos:prefLabel "Diploma"@en-US; 
   skos:definition "Awarded by an educational establishment to show that someone has successfully completed a course of study or equivalent."@en-US;
+  skos:narrower credType:secondarySchoolDiploma ;
+  skos:narrower credType:generalEducationDevelopment ;  
   skos:inScheme credType: ;
   vs:term_status "unstable" .
   
+# SECONDARY SCHOOL DIPLOMA
+credType:secondarySchoolDiploma a skos:Concept;
+  skos:prefLabel "Secondary School Diploma"@en-US; 
+  skos:definition "A diploma awarded by secondary education institutions for successful completion of a secondary school program typically lasting four years."@en-US;
+  skos:broader credType:diploma ;
+  skos:inScheme credType: ;
+  vs:term_status "unstable" .
+
+# GENERAL EDUCATION DEVELOPMENT (GED)
+credType:generalEducationDevelopment a skos:Concept;
+  skos:prefLabel "General Education Development (GED)"@en-US; 
+  skos:definition "A credential awarded by examination that demonstrates that an individual has acquired secondary school-level academic skills."@en-US;
+  skos:broader credType:diploma ;
+  skos:inScheme credType: ;
+  vs:term_status "unstable" .
+
 # LICENSE   
 credType:license a skos:Concept;
   skos:prefLabel "License"@en-US; 
-  skos:definition "The permission granted by competent authority to exercise a certain privilege that, without such authorization, would constitute an illegal act."@en-US;
+  skos:definition "A credential awarded by a government agency that constitutes legal authority to do a specific job and/or utilize a specific item, system or infrastructure and are typically earned through some combination of degree or certificate attainment, certifications, assessments, work experience, and/or fees, and are time-limited and must be renewed periodically."@en-US;
   skos:inScheme credType: ;
   vs:term_status "unstable" .
   
 # MICRO-CREDENTIAL   
 credType:microCredential a skos:Concept;
   skos:prefLabel "Micro-Credential"@en-US; 
-  skos:definition "Validated indicator of accomplishment, skill, quality, or interest that can be earned in many learning environments such as MOOCs that may or may not be issued a digital badge."@en-US;
+  skos:definition "A credential that attests to achievement of a specific knowledge, skill, or competency and may include, but is not limited to, credentials such as digital badges."@en-US;
   skos:inScheme credType: ;
   vs:term_status "unstable" .
   
-# MILITARY CREDENTIAL   
-credType:militaryCredential a skos:Concept;
-  skos:prefLabel "Military Credential"@en-US; 
-  skos:definition "A qualification awarded by the military to show that a soldier is qualified to perform a job or task based on a course of study or equivalent experience."@en-US;
-  skos:inScheme credType: ;
-  vs:term_status "unstable" .
-  
-# NANODEGREE   
-credType:nanodegree a skos:Concept;
-  skos:prefLabel "Nanodegree"@en-US; 
-  skos:definition "A nanodegree program is a compact online curriculum designed to get you the skills that employers believe are key to get a job in technology."@en-US;
-  skos:scopeNote "A nonodegree focuses on learning by doing. It is typically comprised of 5 to 8 projects with relevant courses to support the skills needed to complete those projects."@en-US ;
+# QUALITY ASSURANCE CREDENTIAL   
+credType:qualityAssuranceCredential a skos:Concept;
+  skos:prefLabel "Quality Assurance Credential"@en-US; 
+  skos:definition "A credential assuring that an organization, program, or awarded credential meets prescribed requirements and may include development and administration of qualifying examinations."@en-US;
   skos:inScheme credType: ;
   vs:term_status "unstable" .


### PR DESCRIPTION
This update brings the Credential Type vocabulary (classes) definitions
into alignment with the changes presented to the TAC on 2016-06-24
call. However, it does not delete DIGITAL BADGE pending TAC discussions
and consensus