### PR TITLE
Deleting reference to badge in micro-credential

### DIFF
--- a/credentialType.ttl
+++ b/credentialType.ttl
@@ -187,7 +187,7 @@ credType:license a skos:Concept;
 # MICRO-CREDENTIAL   
 credType:microCredential a skos:Concept;
   skos:prefLabel "Micro-Credential"@en-US; 
-  skos:definition "A credential that attests to achievement of a specific knowledge, skill, or competency and may include, but is not limited to, credentials such as digital badges."@en-US;
+  skos:definition "A credential that attests to achievement of a specific knowledge, skill, or competency."@en-US;
   skos:inScheme credType: ;
   vs:term_status "unstable" .
   


### PR DESCRIPTION
I thought ai had removed the reference to badge in microcredential but apparently did not.