### PR TITLE
Turtle files for controlled vocabulries

### DIFF
--- a/agentSector.ttl
+++ b/agentSector.ttl
@@ -1,0 +1,49 @@
+@prefix agentSector: <https://purl.org/ctdl/vocabs/agentSector/> .
+@prefix dc: <http://purl.org/dc/elements/1.1/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix schema: <http://schema.org/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix bibo: <http://purl.org/ontology/bibo/status/> .
+@prefix vs: <http://www.w3.org/2003/06/sw-vocab-status/ns#> .
+
+# AGENT SECTOR VOCABULARY DESCRIPTION
+agentSector: a skos:ConceptScheme;
+   dc:title "CTI Agent Sector Vocabulary" ;
+   dc:creator "Credential Transparency Initiative (CTI)"@en-US ;
+   dc:description "A concept scheme that defines an agent's categorization in the public/private sectors."@en-US ;
+   dct:created "2016-09-07"^^xsd:date ;
+   dct:source "Sources consulted include Integrated Postsecondary Education Data System (IPEDS)."@en-US ;
+   dct:license <http://creativecommons.org/licenses/by/4.0/> ;                         
+   adms:status bibo:draft . 
+   
+# CONCEPT: BUSINESS-INDUSTRY ASSOCIATION
+agentSector:BusinessIndustryAssociation a skos:Concept;
+  skos:prefLabel "Business-Industry Association"@en-US; 
+  skos:definition "A membership organization primarily engaged in promoting the interests of their business members and providing them with services that may involve the provision of education and credentialing services."@en-US;
+  skos:inScheme agentSector: ;
+  vs:term_status "unstable" .
+  
+# CONCEPT: PRIVATE FOR-PROFIT
+agentSector:PrivateForProfit a skos:Concept;
+  skos:prefLabel "Private For-Profit Institution"@en-US; 
+  skos:definition "A private institution in which the individual(s) or agency in control receives compensation other than wages, rent, or other expenses for the assumption of risk."@en-US;
+  skos:inScheme agentSector: ;
+  vs:term_status "unstable" . 
+  
+# CONCEPT: PRIVATE NON-PROFIT
+agentSector:PrivateNonProfit a skos:Concept;
+  skos:prefLabel "Private Not-For-Profit Institution"@en-US; 
+  skos:definition "A private institution in which the individual(s) or agency in control receives no compensation, other than wages, rent, or other expenses for the assumption of risk."@en-US;
+  skos:inScheme agentSector: ;
+  vs:term_status "unstable" .
+  
+# CONCEPT: PUBLIC
+agentSector:Public a skos:Concept;
+  skos:prefLabel "Public Institution"@en-US; 
+  skos:definition "An educational institution whose programs and activities are operated by publicly elected or appointed school officials and which is supported primarily by public funds."@en-US;
+  skos:inScheme agentSector: ;
+  vs:term_status "unstable" .  

--- a/assessmentDelivery.ttl
+++ b/assessmentDelivery.ttl
@@ -1,0 +1,41 @@
+@prefix assessDelivery: <https://purl.org/ctdl/vocabs/assessmentDelivery/> .
+@prefix dc: <http://purl.org/dc/elements/1.1/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix schema: <http://schema.org/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix bibo: <http://purl.org/ontology/bibo/status/> .
+@prefix vs: <http://www.w3.org/2003/06/sw-vocab-status/ns#> .
+
+# ASSESSMENT DELIVERY TYPE VOCABULARY DESCRIPTION
+assessDelivery: a skos:ConceptScheme;
+    dc:title "CTI Assessment Delivery Type Vocabulary" ;
+    dc:creator "Credential Transparency Initiative (CTI)"@en-US ;
+    dc:description "A concept scheme that defines assessment delivery types."@en-US ;
+    dct:created "2016-09-07"^^xsd:date ;
+    dct:license <http://creativecommons.org/licenses/by/4.0/> ;                         
+    adms:status bibo:draft . 
+   
+# CONCEPT: IN-PERSON
+assessDelivery:InPerson a skos:Concept;
+    skos:prefLabel "In-Person"@en-US; 
+    skos:definition "Assessments taken via physical presence of the instructor."@en-US;
+    skos:inScheme assessDelivery: ;
+    vs:term_status "unstable" .
+  
+# CONCEPT: ONLINE
+assessDelivery:Online a skos:Concept;
+    skos:prefLabel "Online"@en-US; 
+    skos:definition "Assessments taken via the Internet."@en-US;
+    skos:inScheme assessDelivery: ;
+    vs:term_status "unstable" .
+    
+# CONCEPT: PROCTORED
+assessDelivery:Proctored a skos:Concept;
+    skos:prefLabel "Proctored"@en-US; 
+    skos:definition "The assessment is administered in a proctored setting."@en-US;
+    skos:inScheme assessDelivery: ;
+    vs:term_status "unstable" .    

--- a/assessmentMethod.ttl
+++ b/assessmentMethod.ttl
@@ -1,0 +1,121 @@
+@prefix assessMethod: <https://purl.org/ctdl/vocabs/assessmentMethod/> .
+@prefix dc: <http://purl.org/dc/elements/1.1/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix schema: <http://schema.org/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix bibo: <http://purl.org/ontology/bibo/status/> .
+@prefix vs: <http://www.w3.org/2003/06/sw-vocab-status/ns#> .
+
+# ASSESSMENT METHOD VOCABULARY DESCRIPTION
+assessMethod: a skos:ConceptScheme;
+    dc:title "CTI Assessment Method Vocabulary" ;
+    dc:creator "Credential Transparency Initiative (CTI)"@en-US ;
+    dc:description "A concept scheme that defines methods of assessment."@en-US ;
+    dct:created "2016-09-07"^^xsd:date ;
+    dct:source "Sources consulted include Integrated Postsecondary Education Data System (IPEDS)."@en-US ;
+    dct:license <http://creativecommons.org/licenses/by/4.0/> ;                         
+    adms:status bibo:draft . 
+   
+# CONCEPT: ACHIEVEMENT TEST
+assessMethod:AchievementTest a skos:Concept;
+    skos:prefLabel "Achievement Test"@en-US; 
+    skos:definition "A frequently  standardized test developed to measure skills and knowledge learned in a given educational level."@en-US;
+    skos:inScheme assessMethod: ;
+    vs:term_status "unstable" .
+  
+# CONCEPT: ADVANCED PLACEMENT TEST
+assessMethod:AdvancedPlacementTest a skos:Concept ;
+    skos:prefLabel "Advanced Placement Test"@en-US ; 
+    skos:definition "Assessment based on scores from examination at the conclusion of advanced placement courses in secondary school for purposes including postsecondary-level credit or placement in advanced postseconday-level courses."@en-US ;
+    skos:inScheme assessMethod: ;
+    vs:term_status "unstable" . 
+  
+# CONCEPT: ALTERNATE ASSESSMENT
+assessMethod:AlternateAssessment a skos:Concept ;
+    skos:prefLabel "Alternate Assessment"@en-US ;
+    skos:definition "Assessments other than traditional paper-and-pencil, short answer tests that focus on what students can do without emphasizing their weaknesses, especially in test-taking skills."@en-US ;
+    dct:source "Adapted from: http://www.learnnc.org/lp/pages/7041"@en-US ;
+    skos:inScheme assessMethod: ;
+    vs:term_status "unstable" . 
+  
+# CONCEPT: CAPSTONE PROJECT
+assessMethod:CapstoneProject a skos:Concept ;
+    skos:prefLabel "Capstone/Exhibition Project"@en-US ;
+    skos:definition "A multifaceted assignment that serves as a culminating academic and intellectual experience for students, typically during their final year of study."@en-US ;
+    dct:source "Adapted from: http://edglossary.org/capstone-project/"@en-US ;
+    skos:inScheme assessMethod: ;
+    vs:term_status "unstable" . 
+    
+# CONCEPT: CLASS PARTICIPATION
+assessMethod:ClassParticipation a skos:Concept ;
+    skos:prefLabel "Class Participation"@en-US ;
+    skos:definition "Assessment based on the extent and quality of contributions to discussion."@en-US ;
+    skos:inScheme assessMethod: ;
+    vs:term_status "unstable" .  
+    
+# CONCEPT: DEMONSTRATION
+assessMethod:Demonstration a skos:Concept ;
+    skos:prefLabel "Demonstration"@en-US ;
+    skos:definition "Written record of an observed demonstration including explanation of factors assessed."@en-US ;
+    skos:inScheme assessMethod: ;
+    vs:term_status "unstable" .
+    
+# CONCEPT: ESSAY
+assessMethod:Essay a skos:Concept ;
+    skos:prefLabel "Essay"@en-US ;
+    skos:definition "Short piece of writing that fashions a coherent set of ideas on a particular subject."@en-US ;
+    skos:inScheme assessMethod: ;
+    vs:term_status "unstable" .             
+     
+# CONCEPT: JOB EVALUATION
+assessMethod:JobEvaluation a skos:Concept ;
+    skos:prefLabel "Job Evaluation"@en-US ;
+    skos:definition "Supervisor's evaluation of on-the-job performance."@en-US ;
+    skos:inScheme assessMethod: ;
+    vs:term_status "unstable" .
+    
+# CONCEPT: MULTIPLE CHOICE TEST
+assessMethod:MultipleChoiceTest a skos:Concept ;
+    skos:prefLabel "Multiple Choice Test"@en-US ;
+    skos:definition "Test comprised of questions accompanied by several possible answers from which the candidate must try to choose the correct one."@en-US ;
+    skos:inScheme assessMethod: ;
+    vs:term_status "unstable" . 
+    
+# CONCEPT: OBSERVATION
+assessMethod:Observation a skos:Concept ;
+    skos:prefLabel "Observation"@en-US ;
+    skos:definition "Evaluation based on expert observation of performace of a prescribed action."@en-US ;
+    skos:inScheme assessMethod: ;
+    vs:term_status "unstable" .
+    
+# CONCEPT: ORAL EXAMINATION
+assessMethod:OralExam a skos:Concept ;
+    skos:prefLabel "Oral Examination"@en-US ;
+    skos:definition "Evaluation based on oral responses to questions."@en-US ;
+    skos:inScheme assessMethod: ;
+    vs:term_status "unstable" .  
+    
+# CONCEPT: PORTFOLIO
+assessMethod:Portfolio a skos:Concept ;
+    skos:prefLabel "Portfolio"@en-US ;
+    skos:definition "Evaluation based on the assessment of creator-selected artifacts demonstrating the knowledge or skills of their creator."@en-US ;
+    skos:inScheme assessMethod: ;
+    vs:term_status "unstable" .
+    
+# CONCEPT: RELATED PERFORMANCE
+assessMethod:RelatedPerformance a skos:Concept ;
+    skos:prefLabel "Related Performance"@en-US ;
+    skos:definition "[ TBD ]"@en-US ;
+    skos:inScheme assessMethod: ;
+    vs:term_status "unstable" . 
+    
+# CONCEPT: SHORT ANSWER EXAMINATION
+assessMethod:ShortAnswer a skos:Concept ;
+    skos:prefLabel "Short Answer Examination"@en-US ;
+    skos:definition "Short-answer evaluation usually testing whether a person has a factual understanding of the relevant information."@en-US ;
+    skos:inScheme assessMethod: ;
+    vs:term_status "unstable" .                         

--- a/assessmentModality.ttl
+++ b/assessmentModality.ttl
@@ -1,0 +1,34 @@
+@prefix assessMode: <https://purl.org/ctdl/vocabs/assessmentMode/> .
+@prefix dc: <http://purl.org/dc/elements/1.1/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix schema: <http://schema.org/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix bibo: <http://purl.org/ontology/bibo/status/> .
+@prefix vs: <http://www.w3.org/2003/06/sw-vocab-status/ns#> .
+
+# ASSESSMENT MODALITY VOCABULARY DESCRIPTION
+assessMode: a skos:ConceptScheme;
+    dc:title "CTI Assessment Modality Vocabulary" ;
+    dc:creator "Credential Transparency Initiative (CTI)"@en-US ;
+    dc:description "A concept scheme that defines the modalities of assessment."@en-US ;
+    dct:created "2016-09-07"^^xsd:date ;
+    dct:license <http://creativecommons.org/licenses/by/4.0/> ;                         
+    adms:status bibo:draft . 
+   
+# CONCEPT: FORMATIVE
+assessMode:Formative a skos:Concept;
+    skos:prefLabel "Formative Assessment"@en-US; 
+    skos:definition "Formal and informal assessment procedures conducted during the learning process to support intentional modification in teaching and learning activities in order to improve learner attainment."@en-US;
+    skos:inScheme assessMode: ;
+    vs:term_status "unstable" .
+  
+# CONCEPT: SUMMATIVE
+assessMode:Summative a skos:Concept ;
+    skos:prefLabel "Summative Assessment"@en-US ; 
+    skos:definition "Assessment of learning at the end of an instructional activity to determine whether some established standard or benchmark has been achieved."@en-US ;
+    skos:inScheme assessMode: ;
+    vs:term_status "unstable" .

--- a/audience.ttl
+++ b/audience.ttl
@@ -1,0 +1,83 @@
+@prefix audience: <https://purl.org/ctdl/vocabs/audience/> .
+@prefix dc: <http://purl.org/dc/elements/1.1/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix schema: <http://schema.org/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix bibo: <http://purl.org/ontology/bibo/status/> .
+@prefix vs: <http://www.w3.org/2003/06/sw-vocab-status/ns#> .
+
+# AUDIENCE TYPE VOCABULARY DESCRIPTION
+audience: a skos:ConceptScheme;
+    dc:title "CTI Audience Type Vocabulary" ;
+    dc:creator "Credential Transparency Initiative (CTI)"@en-US ;
+    dc:description "A concept scheme that defines the types of audience for a resource."@en-US ;
+    dct:created "2016-09-07"^^xsd:date ;
+    dct:license <http://creativecommons.org/licenses/by/4.0/> ;                         
+    adms:status bibo:draft . 
+   
+# CONCEPT: CITIZEN
+audience:Citizen a skos:Concept;
+    skos:prefLabel "Citizen"@en-US; 
+    skos:definition "A legally recognized subject or national of a state or commonwealth, either native or naturalized."@en-US;
+    skos:inScheme audience: ;
+    vs:term_status "unstable" .
+    
+# CONCEPT: CURRENT MILITARY
+audience:CurrentMilitary a skos:Concept;
+    skos:prefLabel "Current Military"@en-US; 
+    skos:definition "A current member of a nation's military."@en-US;
+    skos:inScheme audience: ;
+    vs:term_status "unstable" .
+   
+# CONCEPT: CURRENT STUDENT
+audience:CurrentStudent a skos:Concept;
+    skos:prefLabel "Current Student"@en-US; 
+    skos:definition "A student currently enrolled in an institution of learning."@en-US;
+    skos:inScheme audience: ;
+    vs:term_status "unstable" .
+        
+# CONCEPT: FORMER MILITARY
+audience:FormerMilitary a skos:Concept;
+    skos:prefLabel "Former Military / Veteran"@en-US; 
+    skos:definition "A veteran of military service."@en-US;
+    skos:inScheme audience: ;
+    vs:term_status "unstable" .
+
+# CONCEPT: FORMER STUDENT
+audience:FormerStudent a skos:Concept;
+    skos:prefLabel "Former Student / Alumni"@en-US; 
+    skos:definition "A former student of an institution of learning."@en-US;
+    skos:inScheme audience: ;
+    vs:term_status "unstable" .
+    
+# CONCEPT: MEMBER
+audience:Member a skos:Concept;
+    skos:prefLabel "Member"@en-US; 
+    skos:definition "A member of an organization, society, or recognized group."@en-US;
+    skos:inScheme audience: ;
+    vs:term_status "unstable" .
+   
+# CONCEPT: NON-CITIZEN
+audience:NonCitizen a skos:Concept;
+    skos:prefLabel "Non-Citizen"@en-US; 
+    skos:definition "A person who is not an inhabitant or national of a particular country or other geopolitical region."@en-US;
+    skos:inScheme audience: ;
+    vs:term_status "unstable" .
+    
+# CONCEPT: PRIVATE EMPLOYEE
+audience:PrivateEmployee a skos:Concept;
+    skos:prefLabel "Private Employee"@en-US; 
+    skos:definition "A person employed in the private sector."@en-US;
+    skos:inScheme audience: ;
+    vs:term_status "unstable" .
+    
+# CONCEPT: PUBLIC EMPLOYEE
+audience:PublicEmployee a skos:Concept;
+    skos:prefLabel "Public Employee"@en-US; 
+    skos:definition "A person employed in the public sector."@en-US;
+    skos:inScheme audience: ;
+    vs:term_status "unstable" .                

--- a/audienceLevel.ttl
+++ b/audienceLevel.ttl
@@ -1,0 +1,83 @@
+@prefix audLevel: <https://purl.org/ctdl/vocabs/audienceLevel/> .
+@prefix dc: <http://purl.org/dc/elements/1.1/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix schema: <http://schema.org/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix bibo: <http://purl.org/ontology/bibo/status/> .
+@prefix vs: <http://www.w3.org/2003/06/sw-vocab-status/ns#> .
+
+# AUDIENCE LEVEL VOCABULARY DESCRIPTION
+audLevel: a skos:ConceptScheme;
+    dc:title "CTI Audience Level Vocabulary" ;
+    dc:creator "Credential Transparency Initiative (CTI)"@en-US ;
+    dc:description "A concept scheme that defines the levels of the audience for a resource."@en-US ;
+    dct:created "2016-09-07"^^xsd:date ;
+    dct:license <http://creativecommons.org/licenses/by/4.0/> ;                         
+    adms:status bibo:draft . 
+   
+# CONCEPT: ELEMENTARY SCHOOL
+audLevel:ElementarySchool a skos:Concept;
+    skos:prefLabel "Elementary School"@en-US; 
+    skos:definition "A school for students in their first school years, before they enter secondary education."@en-US;
+    skos:inScheme audLevel: ;
+    vs:term_status "unstable" .
+
+# CONCEPT: KINDERGARTEN
+audLevel:Kindergarten a skos:Concept;
+    skos:prefLabel "Kindergarten"@en-US; 
+    skos:definition "A school or class that prepares children for the first year of elementary school education."@en-US;
+    skos:inScheme audLevel: ;
+    vs:term_status "unstable" .
+
+# CONCEPT: MIDDLE SCHOOL
+audLevel:MiddleSchool a skos:Concept;
+    skos:prefLabel "Middle School"@en-US; 
+    skos:definition "A intermediate school between an elementary school and a high school."@en-US;
+    skos:inScheme audLevel: ;
+    vs:term_status "unstable" .
+
+# CONCEPT: POSTSECONDARY 1-3
+audLevel:Postsecondary1-3 a skos:Concept;
+    skos:prefLabel "Postsecondary (1-3 years)"@en-US; 
+    skos:definition "A post-secondary level between the 1st year and the 3rd year."@en-US;
+    skos:inScheme audLevel: ;
+    vs:term_status "unstable" .
+    
+# CONCEPT: POSTSECONDARY 3-6
+audLevel:Postsecondary3-6 a skos:Concept;
+    skos:prefLabel "Postsecondary (3-6 years)"@en-US; 
+    skos:definition "A post-secondary level between the 3rd year and the 6th year."@en-US;
+    skos:inScheme audLevel: ;
+    vs:term_status "unstable" .
+    
+# CONCEPT: POSTSECONDARY 6 AND OVER
+audLevel:Postsecondary6andOver a skos:Concept;
+    skos:prefLabel "Postsecondary (6+ years)"@en-US; 
+    skos:definition "A post-secondary level from the 6th year and beyond."@en-US;
+    skos:inScheme audLevel: ;
+    vs:term_status "unstable" .
+    
+# CONCEPT: POSTSECONDARY 6 AND OVER
+audLevel:PostsecondaryUnder1 a skos:Concept;
+    skos:prefLabel "Postsecondary (Less than 1 year)"@en-US; 
+    skos:definition "A post-secondary level under 1 year."@en-US;
+    skos:inScheme audLevel: ;
+    vs:term_status "unstable" .
+    
+# CONCEPT: SECONDARY SCHOOL
+audLevel:SecondarySchool a skos:Concept ;
+    skos:prefLabel "Secondary School"@en-US ; 
+    skos:definition "A school that typically comprises year 9 through year 12 of study."@en-US ;
+    skos:inScheme audLevel: ;
+    vs:term_status "unstable" .
+    
+# CONCEPT: TECHNICAL SCHOOL
+audLevel:TechnicalSchool a skos:Concept ;
+    skos:prefLabel "Technical School"@en-US ; 
+    skos:definition "A general term used for a two-year, post-secondary college. "@en-US ;
+    skos:inScheme audLevel: ;
+    vs:term_status "unstable" .                                    

--- a/claimType.ttl
+++ b/claimType.ttl
@@ -1,0 +1,41 @@
+@prefix claimType: <https://purl.org/ctdl/vocabs/claimType/> .
+@prefix dc: <http://purl.org/dc/elements/1.1/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix schema: <http://schema.org/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix bibo: <http://purl.org/ontology/bibo/status/> .
+@prefix vs: <http://www.w3.org/2003/06/sw-vocab-status/ns#> .
+
+# COST TYPE VOCABULARY DESCRIPTION
+claimType: a skos:ConceptScheme;
+    dc:title "CTI Claim Type Vocabulary" ;
+    dc:creator "Credential Transparency Initiative (CTI)"@en-US ;
+    dc:description "A concept scheme that defines the types of claims made."@en-US ;
+    dct:created "2016-09-07"^^xsd:date ;
+    dct:license <http://creativecommons.org/licenses/by/4.0/> ;                         
+    adms:status bibo:draft . 
+   
+# CONCEPT: VERIFIED CLAIM
+claimType:VerifiedClaim a skos:Concept;
+    skos:prefLabel "Verified Claim"@en-US; 
+    skos:definition "Verifiable representation of the credential holder's credential that is controlled by the credentialing organization."@en-US;
+    skos:inScheme claimType: ;
+    vs:term_status "unstable" .
+    
+# CONCEPT: BADGE CLAIM
+claimType:BadgeClaim a skos:Concept;
+    skos:prefLabel "Badge Claim"@en-US; 
+    skos:definition "Verifiable representation of a credential holder’s badge that is controlled by the credentialing organization."@en-US;
+    skos:inScheme claimType: ;
+    vs:term_status "unstable" .
+
+# CONCEPT: TRANSCRIPT CLAIM
+claimType:TranscriptClaim a skos:Concept;
+    skos:prefLabel "Transcript Claim"@en-US; 
+    skos:definition "Verifiable representation of postsecondary courses and degrees that is controlled by the credentialing organization."@en-US;
+    skos:inScheme claimType: ;
+    vs:term_status "unstable" .   

--- a/costType.ttl
+++ b/costType.ttl
@@ -1,0 +1,56 @@
+@prefix costType: <https://purl.org/ctdl/vocabs/costType/> .
+@prefix dc: <http://purl.org/dc/elements/1.1/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix schema: <http://schema.org/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix bibo: <http://purl.org/ontology/bibo/status/> .
+@prefix vs: <http://www.w3.org/2003/06/sw-vocab-status/ns#> .
+
+# COST TYPE VOCABULARY DESCRIPTION
+costType: a skos:ConceptScheme;
+    dc:title "CTI Cost Type Vocabulary" ;
+    dc:creator "Credential Transparency Initiative (CTI)"@en-US ;
+    dc:description "A concept scheme that defines the types of costs of a resource."@en-US ;
+    dct:created "2016-09-07"^^xsd:date ;
+    dct:license <http://creativecommons.org/licenses/by/4.0/> ;                         
+    adms:status bibo:draft . 
+   
+# CONCEPT: APPLICATION
+costType:Application a skos:Concept;
+    skos:prefLabel "Application"@en-US; 
+    skos:definition "Direct cost of applying for a learning opportunity (including programs of study), credential, assessment, or required task."@en-US;
+    skos:inScheme costType: ;
+    vs:term_status "unstable" .
+    
+# CONCEPT: BACKGROUND CHECK
+costType:BackgroundCheck a skos:Concept;
+    skos:prefLabel "Background Check"@en-US; 
+    skos:definition "Direct cost for performance of a required backgroung check."@en-US;
+    skos:inScheme costType: ;
+    vs:term_status "unstable" . 
+   
+# CONCEPT: LEARNING RESOURCE
+costType:LearningResource a skos:Concept;
+    skos:prefLabel "Learning Resource"@en-US; 
+    skos:definition "Direct costs for learning resources such as textbooks, workbooks, labratory fees, and related supplies."@en-US;
+    skos:inScheme costType: ;
+    vs:term_status "unstable" .
+    
+# CONCEPT: STANDALONE/EXTRA ASSESSMENT
+costType:StandaloneAssessment a skos:Concept;
+    skos:prefLabel "Standalone/Extra Assessment"@en-US; 
+    skos:definition "Direct costs of assessments not included as part of a learning opportunity,"@en-US;
+    skos:inScheme costType: ;
+    vs:term_status "unstable" . 
+   
+# CONCEPT: TUITION
+costType:Tuition a skos:Concept;
+    skos:prefLabel "Tuition"@en-US; 
+    skos:definition "Direct costs charged for teaching or instruction by a school, college, or university."@en-US;
+    skos:inScheme costType: ;
+    vs:term_status "unstable" .
+          


### PR DESCRIPTION
Added first drafts of the turtle encoding for the following vocabularies:
> costType.ttl
> claimType.ttl
> agentSector.ttl
> audienceLevel.ttl
> audience.ttl
> assessmentModality.ttl
> assessmentDelivery
> assessmentMethod.